### PR TITLE
Fix multiline yaml syntax error

### DIFF
--- a/WebAPI-reference/dynamics-ce-odata-9/entitytypes/bulkdeletefailure.yml
+++ b/WebAPI-reference/dynamics-ce-odata-9/entitytypes/bulkdeletefailure.yml
@@ -58,8 +58,7 @@ properties:
     - name: owninguser
       type: Edm.Guid
       display_name: "Owning User"
-      description: "Unique identifier of the user who owns the bulk deletion failure record.
-"
+      description: "Unique identifier of the user who owns the bulk deletion failure record. "
       iscomputed: false
       isreadonly: true
 lookup_properties:

--- a/WebAPI-reference/dynamics-ce-odata-9/entitytypes/msdyn_orderlinetransaction.yml
+++ b/WebAPI-reference/dynamics-ce-odata-9/entitytypes/msdyn_orderlinetransaction.yml
@@ -85,11 +85,7 @@ properties:
     - name: msdyn_amountmethod
       type: Edm.Int32
       display_name: "Amount Method"
-      description: "Select the amount calculation method used for this project contract estimate line. Valid values are: 
-0: Multiply Quantity By Price
-1: Fixed Price
-2: Multiply Basis Quantity By Price
-3: Multiply Basis Amount By Percent "
+      description: "Select the amount calculation method used for this project contract estimate line. Valid values are:  0: Multiply Quantity By Price 1: Fixed Price 2: Multiply Basis Quantity By Price 3: Multiply Basis Amount By Percent "
       iscomputed: false
       isreadonly: false
       options:


### PR DESCRIPTION
Hi @KumarVivek @JimDaly  ,

The docs engineering team is migrating all docs repos to a newer v3 engine, with the goal of improved performance and newer features. We've successfully migrated all conceptual repos to v3 and now we are targeting the rest of docs repos, and the ETA for `dynamic365-docs-odata-apis` is end of August.

In our testing, we've found a small problem with the generated YAML files in this repo. See the test run build report [here](https://opbuildstorageprod.blob.core.windows.net/report/2020/6/30/37189a41-dc67-5b0e-6f3d-ff14da4e6734/Commit/202006300134371290-docs-build-v3/workflow_report.html?sv=2016-05-31&sr=b&sig=5gnKWZ1AO2VGbpyw0ylXTn%2BERzrsTxOAmoq9Ini6izY%3D&st=2020-06-30T01:30:33Z&se=2020-07-31T01:35:33Z&sp=r). This is due to switching an updated, more standard compliant YAML parser in v3.

This PR shows the updated YAML files and makes build pass in v3. and to unblock v3 migration. There is probably a need to update the underlying tool that generates these YAML files.

