### PR TITLE
Update docfx.json

### DIFF
--- a/WebAPI-reference/docfx.json
+++ b/WebAPI-reference/docfx.json
@@ -109,7 +109,8 @@
     "overwrite": [],
     "externalReference": [],
     "globalMetadata": {
-      "breadcrumb_path": "~/bc/toc.yml"
+      "breadcrumb_path": "~/bc/toc.yml",
+      "ms.topic": "reference"
     },
     "fileMetadata": {},
     "template": [],

--- a/WebAPI-reference/dynamics-ce-odata-9/about.md
+++ b/WebAPI-reference/dynamics-ce-odata-9/about.md
@@ -1,5 +1,6 @@
 ---
 title: "Microsoft Dataverse and Dynamics 365 Customer Engagement Web API Reference| MicrosoftDocs"
+description: Microsoft Dataverse and Dynamics 365 Customer Engagement Web API Reference
 ms.date: 04/27/2020
 ms.service: "crm-online"
 ms.topic: "reference"

--- a/WebAPI-reference/dynamics-ce-odata-9/about.md
+++ b/WebAPI-reference/dynamics-ce-odata-9/about.md
@@ -51,3 +51,4 @@ objects available to use in the Web API.
 
  [Use the Microsoft Dataverse Web API](/powerapps/developer/common-data-service/webapi/overview)<br/>
  [Use the Dynamics 365 Customer Engagement (on-premises) Web API](/dynamics365/customer-engagement/developer/use-microsoft-dynamics-365-web-api)
+


### PR DESCRIPTION
adding global metadata for reference tracking.

we're doing some analytics that is counting some of the topics in your repo as conceptual rather than as reference. Although I see the metadata tag on individual topics marked as reference it doesn't looks like its being published out to docs (view source on this page: https://docs.microsoft.com/en-us/dynamics365/customer-engagement/web-api/cloneaspatch?view=dynamics-ce-odata-9 for an example) 

Hoping this applies the tags correctly.  

