### PR TITLE
Adding Remarks For QueryExpressionToFetchXml Action

### DIFF
--- a/WebAPI-reference/dynamics-ce-odata-9/actions/QueryExpressionToFetchXml.yml
+++ b/WebAPI-reference/dynamics-ce-odata-9/actions/QueryExpressionToFetchXml.yml
@@ -33,7 +33,7 @@ return_type:
 # This action has no identified unbound entities.
 
 remarks:
-  description: "Type action accepts a Microsoft.Dynamics.CRM.QueryBase however only Microsoft.Dynamics.CRM.QueryExpression can be converted to Fetch. Specify the @odata.type property on the Microsoft.Dynamics.CRM.QueryBase object. The value should be "Microsoft.Dynamics.CRM.QueryExpression"
+  description: "Type action accepts a Microsoft.Dynamics.CRM.QueryBase however only Microsoft.Dynamics.CRM.QueryExpression can be converted to Fetch. Specify the @odata.type property on the Microsoft.Dynamics.CRM.QueryBase object. The value should be Microsoft.Dynamics.CRM.QueryExpression"
   
 href_see_also:
 - text: "Use the Dataverse Web API"

--- a/WebAPI-reference/dynamics-ce-odata-9/actions/QueryExpressionToFetchXml.yml
+++ b/WebAPI-reference/dynamics-ce-odata-9/actions/QueryExpressionToFetchXml.yml
@@ -31,7 +31,10 @@ return_type:
   nullable: false
   type: Microsoft.Dynamics.CRM.QueryExpressionToFetchXmlResponse
 # This action has no identified unbound entities.
-# There are no remarks for this action.
+
+remarks:
+  description: "Type action accepts a Microsoft.Dynamics.CRM.QueryBase however only Microsoft.Dynamics.CRM.QueryExpression can be converted to Fetch. Specify the @odata.type property on the Microsoft.Dynamics.CRM.QueryBase object. The value should be "Microsoft.Dynamics.CRM.QueryExpression"
+  
 href_see_also:
 - text: "Use the Dataverse Web API"
   href: "https://docs.microsoft.com/powerapps/developer/data-platform/webapi/overview"


### PR DESCRIPTION
Adding Remarks For QueryExpressionToFetchXml Action. This is to help developers avoid frustration using this action.